### PR TITLE
Fix issue #249: Show removal of package conflicts

### DIFF
--- a/software_station_pkg.py
+++ b/software_station_pkg.py
@@ -269,6 +269,15 @@ def get_pkg_changes_data(remove_list, install_list):
                 break
             elif stop is True:
                 pkg_to_reinstall.append(line.strip())
+    if 'REMOVED:' in install_pkg:
+        for line in install_pkg_list:
+            if 'REMOVED:' in line:
+                stop = True
+            elif stop is True and line == '':
+                stop = False
+                break
+            elif stop is True:
+                pkg_to_remove.append(line.strip())
     pkg_dictionaire = {
         'remove': pkg_to_remove,
         'upgrade': pkg_to_upgrade,


### PR DESCRIPTION
Software station fails to show the removal of conflicting packages during new package installation. This was reported in [Issue #249](https://github.com/ghostbsd/issues/issues/249). During package installation, removed conflicts are now added to the "REMOVED" list and shown to the user.

## Summary by Sourcery

Bug Fixes:
- Fix issue where conflicting packages removed during installation were not shown to the user